### PR TITLE
feat: Add command line flags for Viper configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ Optional configuration options for using the ZAP feature with a shared directory
 The agent will automatically create a configuration file in the same directory as the agent (`cipherswarmagent.yaml`)
 with the provided configuration options and default options that can be modified.
 
+### Command Line Flags
+
+The agent can also be configured using command line flags. The following flags are available:
+
+- `--api_token` or `-a`: The API token for the CipherSwarm server.
+- `--api_url` or `-u`: The URL of the CipherSwarm server.
+- `--data_path` or `-p`: The path to the directory where the agent will store data.
+- `--gpu_temp_threshold` or `-g`: The temperature threshold for the GPU in degrees Celsius.
+- `--always_use_native_hashcat` or `-n`: Force using the native hashcat binary.
+- `--sleep_on_failure` or `-s`: Duration of sleep after a task failure.
+- `--files_path` or `-f`: The path to the directory where the agent will store task files.
+- `--extra_debugging` or `-e`: Enable additional debugging information.
+- `--status_timer` or `-t`: Interval in seconds for sending status updates to the server.
+- `--write_zaps_to_file` or `-w`: Write zap output to a file in the zaps directory.
+- `--zap_path` or `-z`: The path to the directory where the agent will store zap output files.
+- `--retain_zaps_on_completion` or `-r`: Retain zap files after completing a task.
+- `--help` or `-h`: Show help information.
+- `--version` or `-v`: Show the version of the agent.
+
 ### Running the Agent
 
 To start the agent, run the following:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,3 @@
-// Package cmd
 package cmd
 
 import (
@@ -49,6 +48,54 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cipherswarmagent.yaml)")
 	rootCmd.PersistentFlags().BoolVar(&enableDebug, "debug", false, "Enable debug mode")
 	err := viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().String("api_token", "", "API token for the CipherSwarm server")
+	err = viper.BindPFlag("api_token", rootCmd.PersistentFlags().Lookup("api_token"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().String("api_url", "", "URL of the CipherSwarm server")
+	err = viper.BindPFlag("api_url", rootCmd.PersistentFlags().Lookup("api_url"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().String("data_path", "", "Path to the directory where the agent will store data")
+	err = viper.BindPFlag("data_path", rootCmd.PersistentFlags().Lookup("data_path"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().Int("gpu_temp_threshold", 80, "Temperature threshold for the GPU in degrees Celsius")
+	err = viper.BindPFlag("gpu_temp_threshold", rootCmd.PersistentFlags().Lookup("gpu_temp_threshold"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().Bool("always_use_native_hashcat", false, "Force using the native hashcat binary")
+	err = viper.BindPFlag("always_use_native_hashcat", rootCmd.PersistentFlags().Lookup("always_use_native_hashcat"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().Duration("sleep_on_failure", 60*time.Second, "Duration of sleep after a task failure")
+	err = viper.BindPFlag("sleep_on_failure", rootCmd.PersistentFlags().Lookup("sleep_on_failure"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().String("files_path", "", "Path to the directory where the agent will store task files")
+	err = viper.BindPFlag("files_path", rootCmd.PersistentFlags().Lookup("files_path"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().Bool("extra_debugging", false, "Enable additional debugging information")
+	err = viper.BindPFlag("extra_debugging", rootCmd.PersistentFlags().Lookup("extra_debugging"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().Int("status_timer", 3, "Interval in seconds for sending status updates to the server")
+	err = viper.BindPFlag("status_timer", rootCmd.PersistentFlags().Lookup("status_timer"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().Bool("write_zaps_to_file", false, "Write zap output to a file in the zaps directory")
+	err = viper.BindPFlag("write_zaps_to_file", rootCmd.PersistentFlags().Lookup("write_zaps_to_file"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().String("zap_path", "", "Path to the directory where the agent will store zap output files")
+	err = viper.BindPFlag("zap_path", rootCmd.PersistentFlags().Lookup("zap_path"))
+	cobra.CheckErr(err)
+
+	rootCmd.PersistentFlags().Bool("retain_zaps_on_completion", false, "Retain zap files after completing a task")
+	err = viper.BindPFlag("retain_zaps_on_completion", rootCmd.PersistentFlags().Lookup("retain_zaps_on_completion"))
 	cobra.CheckErr(err)
 
 	setDefaultConfigValues()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,8 +41,8 @@ func Execute() {
 	cobra.CheckErr(err)
 }
 
-// init initializes the Cobra root command by setting up persistent flags and binding them to Viper configuration variables.
-// It also sets default configuration values and ensures that configurations are properly loaded and applied.
+// init initializes the root command and binds various flags to the configuration using Viper.
+// It sets up the required flags and binds them to configuration variables for easy access throughout the application.
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cipherswarmagent.yaml)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,55 +46,55 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cipherswarmagent.yaml)")
-	rootCmd.PersistentFlags().BoolVar(&enableDebug, "debug", false, "Enable debug mode")
+	rootCmd.PersistentFlags().BoolVarP(&enableDebug, "debug", "d", false, "Enable debug mode")
 	err := viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().String("api_token", "", "API token for the CipherSwarm server")
+	rootCmd.PersistentFlags().StringP("api_token", "a", "", "API token for the CipherSwarm server")
 	err = viper.BindPFlag("api_token", rootCmd.PersistentFlags().Lookup("api_token"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().String("api_url", "", "URL of the CipherSwarm server")
+	rootCmd.PersistentFlags().StringP("api_url", "u", "", "URL of the CipherSwarm server")
 	err = viper.BindPFlag("api_url", rootCmd.PersistentFlags().Lookup("api_url"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().String("data_path", "", "Path to the directory where the agent will store data")
+	rootCmd.PersistentFlags().StringP("data_path", "p", "", "Path to the directory where the agent will store data")
 	err = viper.BindPFlag("data_path", rootCmd.PersistentFlags().Lookup("data_path"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().Int("gpu_temp_threshold", 80, "Temperature threshold for the GPU in degrees Celsius")
+	rootCmd.PersistentFlags().IntP("gpu_temp_threshold", "g", 80, "Temperature threshold for the GPU in degrees Celsius")
 	err = viper.BindPFlag("gpu_temp_threshold", rootCmd.PersistentFlags().Lookup("gpu_temp_threshold"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().Bool("always_use_native_hashcat", false, "Force using the native hashcat binary")
+	rootCmd.PersistentFlags().BoolP("always_use_native_hashcat", "n", false, "Force using the native hashcat binary")
 	err = viper.BindPFlag("always_use_native_hashcat", rootCmd.PersistentFlags().Lookup("always_use_native_hashcat"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().Duration("sleep_on_failure", 60*time.Second, "Duration of sleep after a task failure")
+	rootCmd.PersistentFlags().DurationP("sleep_on_failure", "s", 60*time.Second, "Duration of sleep after a task failure")
 	err = viper.BindPFlag("sleep_on_failure", rootCmd.PersistentFlags().Lookup("sleep_on_failure"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().String("files_path", "", "Path to the directory where the agent will store task files")
+	rootCmd.PersistentFlags().StringP("files_path", "f", "", "Path to the directory where the agent will store task files")
 	err = viper.BindPFlag("files_path", rootCmd.PersistentFlags().Lookup("files_path"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().Bool("extra_debugging", false, "Enable additional debugging information")
+	rootCmd.PersistentFlags().BoolP("extra_debugging", "e", false, "Enable additional debugging information")
 	err = viper.BindPFlag("extra_debugging", rootCmd.PersistentFlags().Lookup("extra_debugging"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().Int("status_timer", 3, "Interval in seconds for sending status updates to the server")
+	rootCmd.PersistentFlags().IntP("status_timer", "t", 3, "Interval in seconds for sending status updates to the server")
 	err = viper.BindPFlag("status_timer", rootCmd.PersistentFlags().Lookup("status_timer"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().Bool("write_zaps_to_file", false, "Write zap output to a file in the zaps directory")
+	rootCmd.PersistentFlags().BoolP("write_zaps_to_file", "w", false, "Write zap output to a file in the zaps directory")
 	err = viper.BindPFlag("write_zaps_to_file", rootCmd.PersistentFlags().Lookup("write_zaps_to_file"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().String("zap_path", "", "Path to the directory where the agent will store zap output files")
+	rootCmd.PersistentFlags().StringP("zap_path", "z", "", "Path to the directory where the agent will store zap output files")
 	err = viper.BindPFlag("zap_path", rootCmd.PersistentFlags().Lookup("zap_path"))
 	cobra.CheckErr(err)
 
-	rootCmd.PersistentFlags().Bool("retain_zaps_on_completion", false, "Retain zap files after completing a task")
+	rootCmd.PersistentFlags().BoolP("retain_zaps_on_completion", "r", false, "Retain zap files after completing a task")
 	err = viper.BindPFlag("retain_zaps_on_completion", rootCmd.PersistentFlags().Lookup("retain_zaps_on_completion"))
 	cobra.CheckErr(err)
 


### PR DESCRIPTION
Fixes #48

Add command line flags for Viper configuration options in `cmd/root.go`.

* Add command line flags for `API_TOKEN`, `API_URL`, `DATA_PATH`, `GPU_TEMP_THRESHOLD`, `ALWAYS_USE_NATIVE_HASHCAT`, `SLEEP_ON_FAILURE`, `FILES_PATH`, `EXTRA_DEBUGGING`, `STATUS_TIMER`, `WRITE_ZAPS_TO_FILE`, `ZAP_PATH`, and `RETAIN_ZAPS_ON_COMPLETION`.
* Bind each flag to its corresponding Viper configuration in the `init` function.
* Add proper descriptions for each command line flag in the viper settings.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/unclesp1d3r/CipherSwarmAgent/issues/48?shareId=5892d035-500f-49be-8daa-4d4c27a1b6fd).