### PR TITLE
refactor: divide up large library files into single responsibility files

### DIFF
--- a/lib/agentClient.go
+++ b/lib/agentClient.go
@@ -10,15 +10,12 @@ import (
 	"path"
 	"time"
 
-	"github.com/duke-git/lancet/v2/convertor"
 	"github.com/duke-git/lancet/v2/fileutil"
 	"github.com/duke-git/lancet/v2/pointer"
 	"github.com/shirou/gopsutil/v3/host"
-	"github.com/spf13/viper"
 	sdk "github.com/unclesp1d3r/cipherswarm-agent-sdk-go"
 	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/components"
 	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/operations"
-	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/sdkerrors"
 	"github.com/unclesp1d3r/cipherswarmagent/lib/arch"
 	"github.com/unclesp1d3r/cipherswarmagent/lib/hashcat"
 	"github.com/unclesp1d3r/cipherswarmagent/shared"
@@ -50,28 +47,6 @@ func AuthenticateAgent() error {
 	shared.State.AgentID = response.GetObject().AgentID
 
 	return nil
-}
-
-// handleAuthenticationError handles authentication errors from the CipherSwarm API.
-// It logs detailed error information based on the type of error and returns the original error.
-func handleAuthenticationError(err error) error {
-	var eo *sdkerrors.ErrorObject
-	if errors.As(err, &eo) {
-		shared.Logger.Error("Error connecting to the CipherSwarm API", "error", eo.Error())
-
-		return err
-	}
-	var se *sdkerrors.SDKError
-	if errors.As(err, &se) {
-		shared.Logger.Error("Error connecting to the CipherSwarm API, unexpected error",
-			"status_code", se.StatusCode,
-			"message", se.Message)
-
-		return err
-	}
-	shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
-
-	return err
 }
 
 // GetAgentConfiguration retrieves the agent configuration from the CipherSwarm API and handles errors.
@@ -106,32 +81,6 @@ func GetAgentConfiguration() error {
 	return nil
 }
 
-// handleConfigurationError processes configuration errors by logging them and sending critical error reports.
-// If the error is an sdkerrors.ErrorObject, logs the error and sends a critical error report.
-// If the error is an sdkerrors.SDKError, logs the error with status code and message, and sends a critical error report.
-// For all other errors, logs a critical communication error with the CipherSwarm API.
-func handleConfigurationError(err error) error {
-	var eo *sdkerrors.ErrorObject
-	if errors.As(err, &eo) {
-		shared.Logger.Error("Error getting agent configuration", "error", eo.Error())
-		SendAgentError(eo.Error(), nil, operations.SeverityCritical)
-
-		return err
-	}
-	var se *sdkerrors.SDKError
-	if errors.As(err, &se) {
-		shared.Logger.Error("Error getting agent configuration, unexpected error",
-			"status_code", se.StatusCode,
-			"message", se.Message)
-		SendAgentError(se.Error(), nil, operations.SeverityCritical)
-
-		return err
-	}
-	shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
-
-	return err
-}
-
 // mapConfiguration converts the GetConfigurationResponseBody into an agentConfiguration for use within the agent.
 func mapConfiguration(config *operations.GetConfigurationResponseBody) agentConfiguration {
 	agentConfig := agentConfiguration{
@@ -145,22 +94,6 @@ func mapConfiguration(config *operations.GetConfigurationResponseBody) agentConf
 	}
 
 	return agentConfig
-}
-
-// setNativeHashcatPath sets the path for the native Hashcat binary if it is found in the system, otherwise logs and reports error.
-func setNativeHashcatPath() error {
-	shared.Logger.Debug("Using native Hashcat")
-	binPath, err := findHashcatBinary()
-	if err != nil {
-		shared.Logger.Error("Error finding hashcat binary: ", err)
-		SendAgentError(err.Error(), nil, operations.SeverityCritical)
-
-		return err
-	}
-	shared.Logger.Info("Found Hashcat binary", "path", binPath)
-	viper.Set("hashcat_path", binPath)
-
-	return viper.WriteConfig()
 }
 
 // UpdateAgentMetadata updates the agent's metadata and sends it to the CipherSwarm API.
@@ -215,323 +148,6 @@ func getDevicesList() ([]string, error) {
 	}
 
 	return getDevices()
-}
-
-// getDevices initializes a test Hashcat session and runs a test task, returning the names of available OpenCL devices.
-// An error is logged and returned if the session creation or test task execution fails.
-func getDevices() ([]string, error) {
-	jobParams := hashcat.Params{
-		AttackMode:     hashcat.AttackModeMask,
-		AdditionalArgs: arch.GetAdditionalHashcatArgs(),
-		HashFile:       "60b725f10c9c85c70d97880dfe8191b3", // "a"
-		Mask:           "?l",
-		OpenCLDevices:  "1,2,3",
-	}
-
-	sess, err := hashcat.NewHashcatSession("test", jobParams)
-	if err != nil {
-		return nil, logAndSendError("Failed to create test session", err, operations.SeverityMajor, nil)
-	}
-
-	testStatus, err := runTestTask(sess)
-	if err != nil {
-		return nil, logAndSendError("Error running test task", err, operations.SeverityFatal, nil)
-	}
-
-	return extractDeviceNames(testStatus.Devices), nil
-}
-
-// logAndSendError logs the provided error message and sends an error report with the specified severity and task metadata.
-// Parameters:
-// - message: The error message to be logged.
-// - err: The error object to be logged and reported.
-// - severity: The severity level of the error being reported.
-// - task: A pointer to the task associated with the error, can be nil.
-// Returns the same error passed in.
-func logAndSendError(message string, err error, severity operations.Severity, task *components.Task) error {
-	shared.Logger.Error(message, "error", err)
-	SendAgentError(err.Error(), task, severity)
-
-	return err
-}
-
-// extractDeviceNames extracts the device names from a slice of hashcat.StatusDevice and returns them as a slice of strings.
-func extractDeviceNames(deviceStatuses []hashcat.StatusDevice) []string {
-	devices := make([]string, len(deviceStatuses))
-	for i, device := range deviceStatuses {
-		devices[i] = device.DeviceName
-	}
-
-	return devices
-}
-
-// UpdateCracker checks for updates to the cracker and applies them if available.
-// It starts by logging the beginning of the update process and attempts to fetch the current version of Hashcat.
-// It then calls the API to check if there are any updates available. Depending on the API response, it either handles
-// the update process or logs the absence of any new updates. If any errors occur during these steps, they are logged and handled accordingly.
-func UpdateCracker() {
-	shared.Logger.Info("Checking for updated cracker")
-	currentVersion, err := getCurrentHashcatVersion()
-	if err != nil {
-		shared.Logger.Error("Error getting current hashcat version", "error", err)
-
-		return
-	}
-
-	response, err := SdkClient.Crackers.CheckForCrackerUpdate(Context, &agentPlatform, &currentVersion)
-	if err != nil {
-		handleAPIError("Error connecting to the CipherSwarm API", err, operations.SeverityCritical)
-
-		return
-	}
-
-	if response.StatusCode == http.StatusNoContent {
-		shared.Logger.Debug("No new cracker available")
-
-		return
-	}
-
-	if response.StatusCode == http.StatusOK {
-		update := response.GetCrackerUpdate()
-		if update.GetAvailable() {
-			_ = handleCrackerUpdate(update)
-		} else {
-			shared.Logger.Debug("No new cracker available", "latest_version", update.GetLatestVersion())
-		}
-	} else {
-		shared.Logger.Error("Error checking for updated cracker", "CrackerUpdate", response.RawResponse.Status)
-	}
-}
-
-// handleCrackerUpdate manages the process of updating the cracker tool.
-// It follows these steps:
-// 1. Logs the new cracker update information.
-// 2. Creates a temporary directory for download and extraction.
-// 3. Downloads the cracker archive from the provided URL.
-// 4. Moves the downloaded archive to a predefined location.
-// 5. Extracts the archive to replace the old cracker directory.
-// 6. Validates the new cracker directory and executable.
-// 7. Updates the configuration with the new executable path.
-// Returns an error if any step in the process fails.
-func handleCrackerUpdate(update *components.CrackerUpdate) error {
-	displayNewCrackerAvailable(update)
-
-	tempDir, err := os.MkdirTemp("", "cipherswarm-*")
-	if err != nil {
-		return logAndSendError("Error creating temporary directory", err, operations.SeverityCritical, nil)
-	}
-	defer func(tempDir string) {
-		_ = cleanupTempDir(tempDir)
-	}(tempDir)
-
-	tempArchivePath := path.Join(tempDir, "hashcat.7z")
-	if err := downloadFile(*update.GetDownloadURL(), tempArchivePath, ""); err != nil {
-		return logAndSendError("Error downloading cracker", err, operations.SeverityCritical, nil)
-	}
-
-	newArchivePath, err := moveArchiveFile(tempArchivePath)
-	if err != nil {
-		return logAndSendError("Error moving file", err, operations.SeverityCritical, nil)
-	}
-
-	hashcatDirectory, err := extractHashcatArchive(newArchivePath)
-	if err != nil {
-		return logAndSendError("Error extracting file", err, operations.SeverityCritical, nil)
-	}
-
-	if !validateHashcatDirectory(hashcatDirectory, *update.GetExecName()) {
-		return nil
-	}
-
-	if err := os.Remove(newArchivePath); err != nil {
-		_ = logAndSendError("Error removing 7z file", err, operations.SeverityWarning, nil)
-	}
-
-	viper.Set("hashcat_path", path.Join(shared.State.CrackersPath, "hashcat", *update.GetExecName()))
-	_ = viper.WriteConfig()
-
-	return nil
-}
-
-// cleanupTempDir removes the specified temporary directory and logs any errors encountered. Returns the error if removal fails.
-func cleanupTempDir(tempDir string) error {
-	if err := os.RemoveAll(tempDir); err != nil {
-		return logAndSendError("Error removing temporary directory", err, operations.SeverityCritical, nil)
-	}
-
-	return nil
-}
-
-// validateHashcatDirectory checks if the given hashcat directory exists and contains the specified executable.
-func validateHashcatDirectory(hashcatDirectory, execName string) bool {
-	if !fileutil.IsDir(hashcatDirectory) {
-		shared.Logger.Error("New hashcat directory does not exist", "path", hashcatDirectory)
-
-		return false
-	}
-
-	hashcatBinaryPath := path.Join(hashcatDirectory, execName)
-	if !fileutil.IsExist(hashcatBinaryPath) {
-		shared.Logger.Error("New hashcat binary does not exist", "path", hashcatBinaryPath)
-
-		return false
-	}
-
-	return true
-}
-
-// GetNewTask retrieves a new task from the server.
-// It sends a request using SdkClient, handles any errors, and returns the task if available.
-// If the server responds with no content, it means no new task is available, and the function returns nil without error.
-// For any other unexpected response status, an error is returned.
-func GetNewTask() (*components.Task, error) {
-	response, err := SdkClient.Tasks.GetNewTask(Context)
-	if err != nil {
-		handleAPIError("Error getting new task", err, operations.SeverityCritical)
-
-		return nil, err
-	}
-
-	switch response.StatusCode {
-	case http.StatusNoContent:
-		// No new task available
-		return nil, nil
-	case http.StatusOK:
-		// New task available
-		return response.Task, nil
-	default:
-		return nil, errors.New("bad response: " + response.RawResponse.Status)
-	}
-}
-
-// GetAttackParameters retrieves the attack parameters for a given attackID via the SdkClient.
-// Returns an Attack object if the API call is successful and the response status is OK.
-func GetAttackParameters(attackID int64) (*components.Attack, error) {
-	response, err := SdkClient.Attacks.GetAttack(Context, attackID)
-	if err != nil {
-		handleAPIError("Error getting attack parameters", err, operations.SeverityCritical)
-
-		return nil, err
-	}
-
-	if response.StatusCode == http.StatusOK {
-		return response.Attack, nil
-	}
-
-	return nil, errors.New("bad response: " + response.RawResponse.Status)
-}
-
-// handleAPIError handles errors returned from the CipherSwarm API. Logs error messages and sends error reports based on the error type.
-// Parameters:
-// - message: Description of the error context.
-// - err: The original error object encountered.
-// - severity: The severity level of the error for reporting.
-func handleAPIError(message string, err error, severity operations.Severity) {
-	switch e := err.(type) {
-	case *sdkerrors.ErrorObject:
-		shared.Logger.Error(message, "error", e.Error())
-		SendAgentError(e.Error(), nil, severity)
-	case *sdkerrors.SDKError:
-		shared.Logger.Error(message+", unexpected error",
-			"status_code", e.StatusCode,
-			"message", e.Message)
-		SendAgentError(e.Error(), nil, severity)
-	default:
-		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
-	}
-}
-
-// sendBenchmarkResults sends the collected benchmark results to a server endpoint.
-// It converts each benchmarkResult into a HashcatBenchmark and appends them to a slice.
-// If the conversion fails for a result, it continues to the next result.
-// Creates a SubmitBenchmarkRequestBody with the HashcatBenchmarks slice and submits it via SdkClient.
-// Returns an error if submission or the response received is not successful.
-func sendBenchmarkResults(benchmarkResults []benchmarkResult) error {
-	var benchmarks []components.HashcatBenchmark //nolint:prealloc
-
-	for _, result := range benchmarkResults {
-		benchmark, err := createBenchmark(result)
-		if err != nil {
-			continue
-		}
-		benchmarks = append(benchmarks, benchmark)
-	}
-
-	results := operations.SubmitBenchmarkRequestBody{
-		HashcatBenchmarks: benchmarks,
-	}
-
-	res, err := SdkClient.Agents.SubmitBenchmark(Context, shared.State.AgentID, results)
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode == http.StatusNoContent {
-		return nil
-	}
-
-	return errors.New("bad response: " + res.RawResponse.Status)
-}
-
-// createBenchmark converts a benchmarkResult to a components.HashcatBenchmark struct.
-// It handles the conversion of string fields in benchmarkResult to appropriate types.
-// Returns a HashcatBenchmark instance and an error if any conversion fails.
-func createBenchmark(result benchmarkResult) (components.HashcatBenchmark, error) {
-	hashType, err := convertor.ToInt(result.HashType)
-	if err != nil {
-		return components.HashcatBenchmark{}, fmt.Errorf("failed to convert HashType: %w", err)
-	}
-	runtimeMs, err := convertor.ToInt(result.RuntimeMs)
-	if err != nil {
-		return components.HashcatBenchmark{}, fmt.Errorf("failed to convert RuntimeMs: %w", err)
-	}
-	speedHs, err := convertor.ToFloat(result.SpeedHs)
-	if err != nil {
-		return components.HashcatBenchmark{}, fmt.Errorf("failed to convert SpeedHs: %w", err)
-	}
-	device, err := convertor.ToInt(result.Device)
-	if err != nil {
-		return components.HashcatBenchmark{}, fmt.Errorf("failed to convert Device: %w", err)
-	}
-
-	return components.HashcatBenchmark{
-		HashType:  hashType,
-		Runtime:   runtimeMs,
-		HashSpeed: speedHs,
-		Device:    device,
-	}, nil
-}
-
-// UpdateBenchmarks updates the benchmark metrics using Hashcat.
-// Creates a Hashcat session with benchmark parameters and initiates the benchmarking process.
-// Logs the session start, runs the benchmark task, and updates the results.
-// If any errors occur during session creation or result sending, logs the errors and returns them.
-func UpdateBenchmarks() error {
-	jobParams := hashcat.Params{
-		AttackMode:                hashcat.AttackBenchmark,
-		AdditionalArgs:            arch.GetAdditionalHashcatArgs(),
-		BackendDevices:            Configuration.Config.BackendDevices,
-		OpenCLDevices:             Configuration.Config.OpenCLDevices,
-		EnableAdditionalHashTypes: shared.State.EnableAdditionalHashTypes,
-	}
-
-	sess, err := hashcat.NewHashcatSession("benchmark", jobParams)
-	if err != nil {
-		return logAndSendError("Failed to create benchmark session", err, operations.SeverityMajor, nil)
-	}
-	shared.Logger.Debug("Starting benchmark session", "cmdline", sess.CmdLine())
-
-	displayBenchmarkStarting()
-	benchmarkResult, done := runBenchmarkTask(sess)
-	if done {
-		return nil
-	}
-	displayBenchmarksComplete(benchmarkResult)
-	if err := sendBenchmarkResults(benchmarkResult); err != nil {
-		return logAndSendError("Error updating benchmarks", err, operations.SeverityCritical, nil)
-	}
-
-	return nil
 }
 
 // DownloadFiles downloads the necessary files for the provided attack.
@@ -621,25 +237,6 @@ func SendHeartBeat() *operations.State {
 	return nil
 }
 
-// handleHeartbeatError processes and logs errors occurring during the heartbeat operation.
-// It handles different types of errors and manages logging and reporting based on severity.
-// - For *sdkerrors.ErrorObject: logs a critical error and sends a critical agent error message.
-// - For *sdkerrors.SDKError: logs an unexpected error with status code and message, and sends a critical agent error message.
-// - For all other errors: logs a critical communication error with the CipherSwarm API.
-func handleHeartbeatError(err error) {
-	switch e := err.(type) {
-	case *sdkerrors.ErrorObject:
-		_ = logAndSendError("Error sending heartbeat", e, operations.SeverityCritical, nil)
-	case *sdkerrors.SDKError:
-		shared.Logger.Error("Error sending heartbeat, unexpected error",
-			"status_code", e.StatusCode,
-			"message", e.Message)
-		SendAgentError(e.Error(), nil, operations.SeverityCritical)
-	default:
-		shared.ErrorLogger.Error("Error communicating with the CipherSwarm API", "error", err)
-	}
-}
-
 // logHeartbeatSent logs a debug message indicating a heartbeat was sent if extra debugging is enabled.
 // It also sets the JobCheckingStopped state to false.
 func logHeartbeatSent() {
@@ -675,65 +272,6 @@ func handleStateResponse(stateResponse *operations.SendHeartbeatResponseBody) *o
 	return &state
 }
 
-// RunTask performs a hashcat attack based on the provided task and attack objects.
-// It initializes the task, creates job parameters, starts the hashcat session, and handles task completion or errors.
-// Parameters:
-//   - task: Pointer to the Task object to be run.
-//   - attack: Pointer to the Attack object describing the specifics of the attack.
-//
-// Returns an error if the task could not be run or if the attack session could not be started.
-func RunTask(task *components.Task, attack *components.Attack) error {
-	displayRunTaskStarting(task)
-
-	if attack == nil {
-		return logAndSendError("Attack is nil", errors.New("attack is nil"), operations.SeverityCritical, task)
-	}
-
-	jobParams := createJobParams(task, attack)
-	sess, err := hashcat.NewHashcatSession(convertor.ToString(attack.GetID()), jobParams)
-	if err != nil {
-		return logAndSendError("Failed to create attack session", err, operations.SeverityCritical, task)
-	}
-
-	runAttackTask(sess, task)
-	displayRunTaskCompleted()
-
-	return nil
-}
-
-// createJobParams creates hashcat parameters from the given Task and Attack objects.
-// The function initializes a hashcat.Params struct by extracting and converting fields
-// from the Task and Attack objects. It includes path settings for various resources
-// like hash files, word lists, rule lists, and restore files.
-func createJobParams(task *components.Task, attack *components.Attack) hashcat.Params {
-	return hashcat.Params{
-		AttackMode:       pointer.UnwrapOr(attack.AttackModeHashcat),
-		HashType:         pointer.UnwrapOr(attack.HashMode),
-		HashFile:         path.Join(shared.State.HashlistPath, convertor.ToString(attack.GetHashListID())+".txt"),
-		Mask:             pointer.UnwrapOr(attack.GetMask(), ""),
-		MaskIncrement:    pointer.UnwrapOr(attack.GetIncrementMode(), false),
-		MaskIncrementMin: attack.GetIncrementMinimum(),
-		MaskIncrementMax: attack.GetIncrementMaximum(),
-		MaskCustomCharsets: []string{
-			pointer.UnwrapOr(attack.GetCustomCharset1(), ""),
-			pointer.UnwrapOr(attack.GetCustomCharset2(), ""),
-			pointer.UnwrapOr(attack.GetCustomCharset3(), ""),
-			pointer.UnwrapOr(attack.GetCustomCharset4(), ""),
-		},
-		WordListFilename: resourceNameOrBlank(attack.WordList),
-		RuleListFilename: resourceNameOrBlank(attack.RuleList),
-		MaskListFilename: resourceNameOrBlank(attack.MaskList),
-		AdditionalArgs:   arch.GetAdditionalHashcatArgs(),
-		OptimizedKernels: *attack.Optimized,
-		SlowCandidates:   *attack.SlowCandidateGenerators,
-		Skip:             pointer.UnwrapOr(task.GetSkip(), 0),
-		Limit:            pointer.UnwrapOr(task.GetLimit(), 0),
-		BackendDevices:   Configuration.Config.BackendDevices,
-		OpenCLDevices:    Configuration.Config.OpenCLDevices,
-		RestoreFilePath:  path.Join(shared.State.RestoreFilePath, convertor.ToString(attack.GetID())+".restore"),
-	}
-}
-
 // sendStatusUpdate sends a status update to the server for a given task and session.
 // It ensures the update time is set, converts device statuses, and converts hashcat.Status to cipherswarm.TaskStatus.
 // Finally, it sends the status update to the server and handles the response.
@@ -746,9 +284,21 @@ func sendStatusUpdate(update hashcat.Status, task *components.Task, sess *hashca
 		shared.Logger.Debug("Sending status update", "status", update)
 	}
 
-	// Convert device statuses
-	deviceStatuses := make([]components.DeviceStatus, len(update.Devices))
-	for i, device := range update.Devices {
+	deviceStatuses := convertDeviceStatuses(update.Devices)
+	taskStatus := convertToTaskStatus(update, deviceStatuses)
+
+	// Send status update to the server
+	resp, err := SdkClient.Tasks.SendStatus(Context, task.GetID(), taskStatus)
+	if err != nil {
+		handleStatusUpdateError(err, task, sess)
+		return
+	}
+	handleSendStatusResponse(resp, task)
+}
+
+func convertDeviceStatuses(devices []hashcat.StatusDevice) []components.DeviceStatus {
+	deviceStatuses := make([]components.DeviceStatus, len(devices))
+	for i, device := range devices {
 		deviceStatuses[i] = components.DeviceStatus{
 			DeviceID:    device.DeviceID,
 			DeviceName:  device.DeviceName,
@@ -758,9 +308,11 @@ func sendStatusUpdate(update hashcat.Status, task *components.Task, sess *hashca
 			Temperature: device.Temp,
 		}
 	}
+	return deviceStatuses
+}
 
-	// Convert hashcat.Status to cipherswarm.TaskStatus
-	taskStatus := components.TaskStatus{
+func convertToTaskStatus(update hashcat.Status, deviceStatuses []components.DeviceStatus) components.TaskStatus {
+	return components.TaskStatus{
 		OriginalLine: update.OriginalLine,
 		Time:         update.Time,
 		Session:      update.Session,
@@ -786,16 +338,9 @@ func sendStatusUpdate(update hashcat.Status, task *components.Task, sess *hashca
 		TimeStart:       time.Unix(update.TimeStart, 0),
 		EstimatedStop:   time.Unix(update.EstimatedStop, 0),
 	}
+}
 
-	// Send status update to the server
-	resp, err := SdkClient.Tasks.SendStatus(Context, task.GetID(), taskStatus)
-	if err != nil {
-		handleStatusUpdateError(err, task, sess)
-
-		return
-	}
-
-	// Handle non-error responses
+func handleSendStatusResponse(resp *operations.SendStatusResponse, task *components.Task) {
 	switch resp.StatusCode {
 	case http.StatusNoContent:
 		if shared.State.ExtraDebugging {
@@ -804,60 +349,6 @@ func sendStatusUpdate(update hashcat.Status, task *components.Task, sess *hashca
 	case http.StatusAccepted:
 		shared.Logger.Debug("Status update sent, but stale")
 		getZaps(task)
-	}
-}
-
-// handleStatusUpdateError handles specific error types during a status update and logs or processes them accordingly.
-func handleStatusUpdateError(err error, task *components.Task, sess *hashcat.Session) {
-	var eo *sdkerrors.ErrorObject
-	if errors.As(err, &eo) {
-		_ = logAndSendError("Error sending status update", eo, operations.SeverityCritical, task)
-
-		return
-	}
-
-	var se *sdkerrors.SDKError
-	if errors.As(err, &se) {
-		handleSDKError(se, task, sess)
-
-		return
-	}
-
-	shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
-}
-
-// handleSDKError handles errors from the SDK by taking appropriate action based on the error's status code.
-func handleSDKError(se *sdkerrors.SDKError, task *components.Task, sess *hashcat.Session) {
-	switch se.StatusCode {
-	case http.StatusNotFound:
-		// Not an error, just log and kill the task
-		handleTaskNotFound(task, sess)
-	case http.StatusGone:
-		// Not an error, just log and pause the task
-		handleTaskGone(task, sess)
-	default:
-		_ = logAndSendError("Error connecting to the CipherSwarm API, unexpected error", se, operations.SeverityCritical, task)
-	}
-}
-
-// handleTaskNotFound handles the scenario where a task is not found in the system.
-// It logs an error message with the task ID, attempts to kill the session, and cleans up the session.
-// If killing the session fails, it logs and sends an error.
-func handleTaskNotFound(task *components.Task, sess *hashcat.Session) {
-	shared.Logger.Error("Task not found", "task_id", task.GetID())
-	shared.Logger.Info("Killing task", "task_id", task.GetID())
-	shared.Logger.Info("It is possible that multiple errors appear as the task takes some time to kill. This is expected.")
-	if err := sess.Kill(); err != nil {
-		_ = logAndSendError("Error killing task", err, operations.SeverityCritical, task)
-	}
-	sess.Cleanup()
-}
-
-// handleTaskGone handles the termination of a task when it is no longer needed, ensuring the session is appropriately killed.
-func handleTaskGone(task *components.Task, sess *hashcat.Session) {
-	shared.Logger.Info("Pausing task", "task_id", task.GetID())
-	if err := sess.Kill(); err != nil {
-		_ = logAndSendError("Error pausing task", err, operations.SeverityFatal, task)
 	}
 }
 
@@ -882,44 +373,6 @@ func getZaps(task *components.Task) {
 	if res.ResponseStream != nil {
 		_ = handleResponseStream(task, res.ResponseStream)
 	}
-}
-
-// handleGetZapsError handles different types of errors when fetching zaps from the server.
-// - If the error is of type sdkerrors.ErrorObject, it logs the error and sends a critical agent error message.
-// - If the error is of type sdkerrors.SDKError, it logs an unexpected error with its status code and message, then sends a critical agent error message.
-// - For all other errors, it logs a critical communication error with the CipherSwarm API.
-func handleGetZapsError(err error) {
-	switch e := err.(type) {
-	case *sdkerrors.ErrorObject:
-		shared.Logger.Error("Error getting zaps from server", "error", e.Error())
-		SendAgentError(e.Error(), nil, operations.SeverityCritical)
-	case *sdkerrors.SDKError:
-		shared.Logger.Error("Error getting zaps from server, unexpected error",
-			"status_code", e.StatusCode,
-			"message", e.Message)
-		SendAgentError(e.Error(), nil, operations.SeverityCritical)
-	default:
-		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
-	}
-}
-
-// handleResponseStream processes a received response stream for a given task, writing it to a zap file on disk.
-// Constructs the zap file path from the task ID, removes existing zap files if necessary, and writes the new zap file.
-// Logs debug information for non-critical errors when removing existing files and logs critical errors for failures in creating or writing the zap file.
-func handleResponseStream(task *components.Task, responseStream io.Reader) error {
-	zapFilePath := path.Join(shared.State.ZapsPath, fmt.Sprintf("%d.zap", task.GetID()))
-
-	if err := removeExistingZapFile(zapFilePath); err != nil {
-		// It's not critical to remove the existing zap file since we're going to overwrite it anyway
-		_ = logAndSendError("Error removing existing zap file", err, operations.SeverityCritical, task)
-	}
-
-	if err := createAndWriteZapFile(zapFilePath, responseStream, task); err != nil {
-		// This is a critical error since we need the zap file to be written
-		return logAndSendError("Error handling zap file", err, operations.SeverityCritical, task)
-	}
-
-	return nil
 }
 
 // removeExistingZapFile removes the zap file at the given path if it exists, logging debug information.
@@ -953,155 +406,11 @@ func createAndWriteZapFile(zapFilePath string, responseStream io.Reader, task *c
 	return nil
 }
 
-// SendAgentError sends an error message to the centralized server, including metadata and severity level.
-// - stdErrLine: The error message string to send.
-// - task: Pointer to the task associated with the error, can be nil.
-// - severity: The severity level of the error (e.g., critical, warning).
-// The function prepares metadata including platform and agent version details, constructs the request body,
-// and sends it to the server using the SDK client. If the sending fails, it handles the error accordingly.
-func SendAgentError(stdErrLine string, task *components.Task, severity operations.Severity) {
-	var taskID *int64
-	if task != nil {
-		taskID = &task.ID
-	}
-
-	metadata := &operations.Metadata{
-		ErrorDate: time.Now(),
-		Other: map[string]any{
-			"platform": agentPlatform,
-			"version":  AgentVersion,
-		},
-	}
-
-	agentError := &operations.SubmitErrorAgentRequestBody{
-		Message:  stdErrLine,
-		Metadata: metadata,
-		Severity: severity,
-		AgentID:  shared.State.AgentID,
-		TaskID:   taskID,
-	}
-
-	if _, err := SdkClient.Agents.SubmitErrorAgent(Context, shared.State.AgentID, agentError); err != nil {
-		handleSendError(err)
-	}
-}
-
-// handleSendError handles errors that occur during communication with the server.
-// It logs the error locally and attempts to send critical errors to the server.
-func handleSendError(err error) {
-	switch e := err.(type) {
-	case *sdkerrors.ErrorObject:
-		shared.Logger.Error("Error sending agent error to server", "error", e.Error())
-		SendAgentError(e.Error(), nil, operations.SeverityCritical)
-	case *sdkerrors.SDKError:
-		shared.Logger.Error("Error sending agent error to server, unexpected error",
-			"status_code", e.StatusCode,
-			"message", e.Message)
-		SendAgentError(e.Error(), nil, operations.SeverityCritical)
-	default:
-		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
-	}
-}
-
-// AcceptTask attempts to accept the given task identified by its ID.
-// It logs an error and returns if the task is nil.
-// If the task is successfully accepted, it logs a debug message indicating success.
-// In case of an error during task acceptance, it handles the error and returns it.
-func AcceptTask(task *components.Task) error {
-	if task == nil {
-		shared.Logger.Error("Task is nil")
-
-		return errors.New("task is nil")
-	}
-
-	_, err := SdkClient.Tasks.SetTaskAccepted(Context, task.GetID())
-	if err != nil {
-		handleAcceptTaskError(err)
-
-		return err
-	}
-
-	shared.Logger.Debug("Task accepted")
-
-	return nil
-}
-
-// handleAcceptTaskError handles errors that occur when attempting to accept a task.
-// It distinguishes between different error types and logs messages accordingly.
-// For specific SDK errors, it logs the error and sends an info-severity agent error.
-// For unexpected SDK errors, it logs the error including status code and message, and sends a critical-severity agent error.
-// For all other errors, it logs a critical communication error.
-func handleAcceptTaskError(err error) {
-	switch e := err.(type) {
-	case *sdkerrors.ErrorObject:
-		// Handle specific error responses
-		shared.Logger.Error("Error accepting task", "error", e.Error())
-		SendAgentError(e.Error(), nil, operations.SeverityInfo)
-	case *sdkerrors.SDKError:
-		// Handle unexpected errors
-		shared.Logger.Error("Error accepting task, unexpected error",
-			"status_code", e.StatusCode,
-			"message", e.Message)
-		SendAgentError(e.Error(), nil, operations.SeverityCritical)
-	default:
-		// Handle critical communication errors
-		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
-	}
-}
-
-// markTaskExhausted marks the given task as exhausted by notifying the server.
-// Logs an error if the task is nil or if notifying the server fails.
-func markTaskExhausted(task *components.Task) {
-	if task == nil {
-		shared.Logger.Error("Task is nil")
-
-		return
-	}
-
-	_, err := SdkClient.Tasks.SetTaskExhausted(Context, task.GetID())
-	if err != nil {
-		handleTaskError(err, "Error notifying server of task exhaustion")
-	}
-}
-
 // SendAgentShutdown notifies the server of the agent shutdown and handles any errors during the API call.
 func SendAgentShutdown() {
 	_, err := SdkClient.Agents.SetAgentShutdown(Context, shared.State.AgentID)
 	if err != nil {
 		handleAPIError("Error notifying server of agent shutdown", err, operations.SeverityCritical)
-	}
-}
-
-// AbandonTask sets the given task to an abandoned state using the SdkClient and logs any errors that occur.
-// If the task is nil, it logs an error and returns immediately.
-func AbandonTask(task *components.Task) {
-	if task == nil {
-		shared.Logger.Error("Task is nil")
-
-		return
-	}
-
-	_, err := SdkClient.Tasks.SetTaskAbandoned(Context, task.GetID())
-	if err != nil {
-		handleTaskError(err, "Error notifying server of task abandonment")
-	}
-}
-
-// handleTaskError handles different types of errors encountered during task operations and logs appropriate messages.
-// It sends error details to a centralized server based on the error's severity level.
-func handleTaskError(err error, message string) {
-	switch e := err.(type) {
-	case *sdkerrors.ErrorObject:
-		shared.Logger.Error(message, "error", e.Error())
-		SendAgentError(e.Error(), nil, operations.SeverityCritical)
-	case *sdkerrors.SetTaskAbandonedResponseBody:
-		shared.Logger.Error("Notified server of task abandonment, but it could not update the task properly", "error", e.State)
-		SendAgentError(e.Error(), nil, operations.SeverityWarning)
-	case *sdkerrors.SDKError:
-		shared.Logger.Error(message, "status_code", e.StatusCode, "message", e.Message)
-		SendAgentError(e.Error(), nil, operations.SeverityCritical)
-	default:
-		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
 	}
 }
 
@@ -1141,35 +450,4 @@ func sendCrackedHash(hash hashcat.Result, task *components.Task) {
 	if response.StatusCode == http.StatusNoContent {
 		shared.Logger.Info("Hashlist completed", "hash", hash.Hash)
 	}
-}
-
-// handleSendCrackError processes different types of errors encountered when communicating with the CipherSwarm API.
-// Logs errors based on their type and reports major or critical severity, or logs a critical error for unknown types.
-func handleSendCrackError(err error) {
-	switch e := err.(type) {
-	case *sdkerrors.ErrorObject:
-		shared.Logger.Error("Error notifying server of cracked hash, task not found", "error", e.Error())
-		SendAgentError(e.Error(), nil, operations.SeverityMajor)
-	case *sdkerrors.SDKError:
-		shared.Logger.Error("Error sending cracked hash to server, unexpected error",
-			"status_code", e.StatusCode,
-			"message", e.Message)
-		SendAgentError(e.Error(), nil, operations.SeverityCritical)
-	default:
-		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
-	}
-}
-
-// writeCrackedHashToFile writes a cracked hash and its plaintext to a specified file.
-// It constructs the output string using the hash and plaintext, then writes it to a task-specific file in the ZapsPath.
-// Returns an error if the file writing operation fails.
-func writeCrackedHashToFile(hash hashcat.Result, task *components.Task) error {
-	hashOut := fmt.Sprintf("%s:%s\n", hash.Hash, hash.Plaintext)
-	hashFile := path.Join(shared.State.ZapsPath, fmt.Sprintf("%d_clientout.zap", task.GetID()))
-	err := fileutil.WriteStringToFile(hashFile, hashOut, true)
-	if err != nil {
-		return logAndSendError("Error writing cracked hash to file", err, operations.SeverityCritical, task)
-	}
-
-	return nil
 }

--- a/lib/benchmarkManager.go
+++ b/lib/benchmarkManager.go
@@ -1,0 +1,177 @@
+package lib
+
+import (
+	"errors"
+	"fmt"
+	"github.com/duke-git/lancet/v2/convertor"
+	"github.com/duke-git/lancet/v2/strutil"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/components"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/operations"
+	"github.com/unclesp1d3r/cipherswarmagent/lib/arch"
+	"github.com/unclesp1d3r/cipherswarmagent/lib/hashcat"
+	"github.com/unclesp1d3r/cipherswarmagent/shared"
+	"net/http"
+	"strings"
+)
+
+// sendBenchmarkResults sends the collected benchmark results to a server endpoint.
+// It converts each benchmarkResult into a HashcatBenchmark and appends them to a slice.
+// If the conversion fails for a result, it continues to the next result.
+// Creates a SubmitBenchmarkRequestBody with the HashcatBenchmarks slice and submits it via SdkClient.
+// Returns an error if submission or the response received is not successful.
+func sendBenchmarkResults(benchmarkResults []benchmarkResult) error {
+	var benchmarks []components.HashcatBenchmark //nolint:prealloc
+
+	for _, result := range benchmarkResults {
+		benchmark, err := createBenchmark(result)
+		if err != nil {
+			continue
+		}
+		benchmarks = append(benchmarks, benchmark)
+	}
+
+	results := operations.SubmitBenchmarkRequestBody{
+		HashcatBenchmarks: benchmarks,
+	}
+
+	res, err := SdkClient.Agents.SubmitBenchmark(Context, shared.State.AgentID, results)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	return errors.New("bad response: " + res.RawResponse.Status)
+}
+
+// createBenchmark converts a benchmarkResult to a components.HashcatBenchmark struct.
+// It handles the conversion of string fields in benchmarkResult to appropriate types.
+// Returns a HashcatBenchmark instance and an error if any conversion fails.
+func createBenchmark(result benchmarkResult) (components.HashcatBenchmark, error) {
+	hashType, err := convertor.ToInt(result.HashType)
+	if err != nil {
+		return components.HashcatBenchmark{}, fmt.Errorf("failed to convert HashType: %w", err)
+	}
+	runtimeMs, err := convertor.ToInt(result.RuntimeMs)
+	if err != nil {
+		return components.HashcatBenchmark{}, fmt.Errorf("failed to convert RuntimeMs: %w", err)
+	}
+	speedHs, err := convertor.ToFloat(result.SpeedHs)
+	if err != nil {
+		return components.HashcatBenchmark{}, fmt.Errorf("failed to convert SpeedHs: %w", err)
+	}
+	device, err := convertor.ToInt(result.Device)
+	if err != nil {
+		return components.HashcatBenchmark{}, fmt.Errorf("failed to convert Device: %w", err)
+	}
+
+	return components.HashcatBenchmark{
+		HashType:  hashType,
+		Runtime:   runtimeMs,
+		HashSpeed: speedHs,
+		Device:    device,
+	}, nil
+}
+
+// UpdateBenchmarks updates the benchmark metrics using Hashcat.
+// Creates a Hashcat session with benchmark parameters and initiates the benchmarking process.
+// Logs the session start, runs the benchmark task, and updates the results.
+// If any errors occur during session creation or result sending, logs the errors and returns them.
+func UpdateBenchmarks() error {
+	jobParams := hashcat.Params{
+		AttackMode:                hashcat.AttackBenchmark,
+		AdditionalArgs:            arch.GetAdditionalHashcatArgs(),
+		BackendDevices:            Configuration.Config.BackendDevices,
+		OpenCLDevices:             Configuration.Config.OpenCLDevices,
+		EnableAdditionalHashTypes: shared.State.EnableAdditionalHashTypes,
+	}
+
+	sess, err := hashcat.NewHashcatSession("benchmark", jobParams)
+	if err != nil {
+		return logAndSendError("Failed to create benchmark session", err, operations.SeverityMajor, nil)
+	}
+	shared.Logger.Debug("Starting benchmark session", "cmdline", sess.CmdLine())
+
+	displayBenchmarkStarting()
+	benchmarkResult, done := runBenchmarkTask(sess)
+	if done {
+		return nil
+	}
+	displayBenchmarksComplete(benchmarkResult)
+	if err := sendBenchmarkResults(benchmarkResult); err != nil {
+		return logAndSendError("Error updating benchmarks", err, operations.SeverityCritical, nil)
+	}
+
+	return nil
+}
+
+// runBenchmarkTask starts a hashcat benchmark session and processes its output.
+// It returns a slice of benchmark results and a boolean indicating an error state.
+func runBenchmarkTask(sess *hashcat.Session) ([]benchmarkResult, bool) {
+	err := sess.Start()
+	if err != nil {
+		shared.Logger.Error("Failed to start benchmark session", "error", err)
+
+		return nil, true
+	}
+
+	var benchmarkResults []benchmarkResult
+	waitChan := make(chan int)
+
+	go func() {
+		defer close(waitChan)
+		for {
+			select {
+			case stdOutLine := <-sess.StdoutLines:
+				handleBenchmarkStdOutLine(stdOutLine, &benchmarkResults)
+			case stdErrLine := <-sess.StderrMessages:
+				handleBenchmarkStdErrLine(stdErrLine)
+			case statusUpdate := <-sess.StatusUpdates:
+				shared.Logger.Debug("Benchmark status update", "status", statusUpdate) // This should never happen
+			case crackedHash := <-sess.CrackedHashes:
+				shared.Logger.Debug("Benchmark cracked hash", "hash", crackedHash) // This should never happen
+			case err := <-sess.DoneChan:
+				if err != nil {
+					shared.Logger.Error("Benchmark session failed", "error", err)
+					SendAgentError(err.Error(), nil, operations.SeverityFatal)
+				}
+
+				return
+			}
+		}
+	}()
+
+	<-waitChan
+
+	return benchmarkResults, false
+}
+
+// handleBenchmarkStdOutLine processes a line of benchmark output, extracting relevant data and appending it to result.
+func handleBenchmarkStdOutLine(line string, results *[]benchmarkResult) {
+	fields := strings.Split(line, ":")
+	if len(fields) != 6 {
+		shared.Logger.Debug("Unknown benchmark line", "line", line)
+
+		return
+	}
+
+	result := benchmarkResult{
+		Device:     fields[0],
+		HashType:   fields[1],
+		RuntimeMs:  fields[3],
+		HashTimeMs: fields[4],
+		SpeedHs:    fields[5],
+	}
+	displayBenchmark(result)
+	*results = append(*results, result)
+}
+
+// handleBenchmarkStdErrLine processes each line from the benchmark's standard error output, logs it, and reports warnings to the server.
+func handleBenchmarkStdErrLine(line string) {
+	displayBenchmarkError(line)
+	if strutil.IsNotBlank(line) {
+		SendAgentError(line, nil, operations.SeverityWarning)
+	}
+}

--- a/lib/crackerUtils.go
+++ b/lib/crackerUtils.go
@@ -1,0 +1,82 @@
+package lib
+
+import (
+	"github.com/duke-git/lancet/v2/fileutil"
+	"github.com/spf13/viper"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/operations"
+	"github.com/unclesp1d3r/cipherswarmagent/shared"
+	"net/http"
+	"path"
+)
+
+// setNativeHashcatPath sets the path for the native Hashcat binary if it is found in the system, otherwise logs and reports error.
+func setNativeHashcatPath() error {
+	shared.Logger.Debug("Using native Hashcat")
+	binPath, err := findHashcatBinary()
+	if err != nil {
+		shared.Logger.Error("Error finding hashcat binary: ", err)
+		SendAgentError(err.Error(), nil, operations.SeverityCritical)
+
+		return err
+	}
+	shared.Logger.Info("Found Hashcat binary", "path", binPath)
+	viper.Set("hashcat_path", binPath)
+
+	return viper.WriteConfig()
+}
+
+// UpdateCracker checks for updates to the cracker and applies them if available.
+// It starts by logging the beginning of the update process and attempts to fetch the current version of Hashcat.
+// It then calls the API to check if there are any updates available. Depending on the API response, it either handles
+// the update process or logs the absence of any new updates. If any errors occur during these steps, they are logged and handled accordingly.
+func UpdateCracker() {
+	shared.Logger.Info("Checking for updated cracker")
+	currentVersion, err := getCurrentHashcatVersion()
+	if err != nil {
+		shared.Logger.Error("Error getting current hashcat version", "error", err)
+
+		return
+	}
+
+	response, err := SdkClient.Crackers.CheckForCrackerUpdate(Context, &agentPlatform, &currentVersion)
+	if err != nil {
+		handleAPIError("Error connecting to the CipherSwarm API", err, operations.SeverityCritical)
+
+		return
+	}
+
+	if response.StatusCode == http.StatusNoContent {
+		shared.Logger.Debug("No new cracker available")
+
+		return
+	}
+
+	if response.StatusCode == http.StatusOK {
+		update := response.GetCrackerUpdate()
+		if update.GetAvailable() {
+			_ = handleCrackerUpdate(update)
+		} else {
+			shared.Logger.Debug("No new cracker available", "latest_version", update.GetLatestVersion())
+		}
+	} else {
+		shared.Logger.Error("Error checking for updated cracker", "CrackerUpdate", response.RawResponse.Status)
+	}
+}
+
+// validateHashcatDirectory checks if the given hashcat directory exists and contains the specified executable.
+func validateHashcatDirectory(hashcatDirectory, execName string) bool {
+	if !fileutil.IsDir(hashcatDirectory) {
+		shared.Logger.Error("New hashcat directory does not exist", "path", hashcatDirectory)
+
+		return false
+	}
+
+	hashcatBinaryPath := path.Join(hashcatDirectory, execName)
+	if !fileutil.IsExist(hashcatBinaryPath) {
+		shared.Logger.Error("New hashcat binary does not exist", "path", hashcatBinaryPath)
+
+		return false
+	}
+
+	return true
+}

--- a/lib/errorUtils.go
+++ b/lib/errorUtils.go
@@ -1,0 +1,368 @@
+package lib
+
+import (
+	"errors"
+	"fmt"
+	"github.com/spf13/viper"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/components"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/operations"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/sdkerrors"
+	"github.com/unclesp1d3r/cipherswarmagent/lib/hashcat"
+	"github.com/unclesp1d3r/cipherswarmagent/shared"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"time"
+)
+
+// handleAuthenticationError handles authentication errors from the CipherSwarm API.
+// It logs detailed error information based on the type of error and returns the original error.
+func handleAuthenticationError(err error) error {
+	var eo *sdkerrors.ErrorObject
+	if errors.As(err, &eo) {
+		shared.Logger.Error("Error connecting to the CipherSwarm API", "error", eo.Error())
+
+		return err
+	}
+	var se *sdkerrors.SDKError
+	if errors.As(err, &se) {
+		shared.Logger.Error("Error connecting to the CipherSwarm API, unexpected error",
+			"status_code", se.StatusCode,
+			"message", se.Message)
+
+		return err
+	}
+	shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
+
+	return err
+}
+
+// handleConfigurationError processes configuration errors by logging them and sending critical error reports.
+// If the error is an sdkerrors.ErrorObject, logs the error and sends a critical error report.
+// If the error is an sdkerrors.SDKError, logs the error with status code and message, and sends a critical error report.
+// For all other errors, logs a critical communication error with the CipherSwarm API.
+func handleConfigurationError(err error) error {
+	var eo *sdkerrors.ErrorObject
+	if errors.As(err, &eo) {
+		shared.Logger.Error("Error getting agent configuration", "error", eo.Error())
+		SendAgentError(eo.Error(), nil, operations.SeverityCritical)
+
+		return err
+	}
+	var se *sdkerrors.SDKError
+	if errors.As(err, &se) {
+		shared.Logger.Error("Error getting agent configuration, unexpected error",
+			"status_code", se.StatusCode,
+			"message", se.Message)
+		SendAgentError(se.Error(), nil, operations.SeverityCritical)
+
+		return err
+	}
+	shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
+
+	return err
+}
+
+// logAndSendError logs the provided error message and sends an error report with the specified severity and task metadata.
+// Parameters:
+// - message: The error message to be logged.
+// - err: The error object to be logged and reported.
+// - severity: The severity level of the error being reported.
+// - task: A pointer to the task associated with the error, can be nil.
+// Returns the same error passed in.
+func logAndSendError(message string, err error, severity operations.Severity, task *components.Task) error {
+	shared.Logger.Error(message, "error", err)
+	SendAgentError(err.Error(), task, severity)
+
+	return err
+}
+
+// handleCrackerUpdate manages the process of updating the cracker tool.
+// It follows these steps:
+// 1. Logs the new cracker update information.
+// 2. Creates a temporary directory for download and extraction.
+// 3. Downloads the cracker archive from the provided URL.
+// 4. Moves the downloaded archive to a predefined location.
+// 5. Extracts the archive to replace the old cracker directory.
+// 6. Validates the new cracker directory and executable.
+// 7. Updates the configuration with the new executable path.
+// Returns an error if any step in the process fails.
+func handleCrackerUpdate(update *components.CrackerUpdate) error {
+	displayNewCrackerAvailable(update)
+
+	tempDir, err := os.MkdirTemp("", "cipherswarm-*")
+	if err != nil {
+		return logAndSendError("Error creating temporary directory", err, operations.SeverityCritical, nil)
+	}
+	defer func(tempDir string) {
+		_ = cleanupTempDir(tempDir)
+	}(tempDir)
+
+	tempArchivePath := path.Join(tempDir, "hashcat.7z")
+	if err := downloadFile(*update.GetDownloadURL(), tempArchivePath, ""); err != nil {
+		return logAndSendError("Error downloading cracker", err, operations.SeverityCritical, nil)
+	}
+
+	newArchivePath, err := moveArchiveFile(tempArchivePath)
+	if err != nil {
+		return logAndSendError("Error moving file", err, operations.SeverityCritical, nil)
+	}
+
+	hashcatDirectory, err := extractHashcatArchive(newArchivePath)
+	if err != nil {
+		return logAndSendError("Error extracting file", err, operations.SeverityCritical, nil)
+	}
+
+	if !validateHashcatDirectory(hashcatDirectory, *update.GetExecName()) {
+		return nil
+	}
+
+	if err := os.Remove(newArchivePath); err != nil {
+		_ = logAndSendError("Error removing 7z file", err, operations.SeverityWarning, nil)
+	}
+
+	viper.Set("hashcat_path", path.Join(shared.State.CrackersPath, "hashcat", *update.GetExecName()))
+	_ = viper.WriteConfig()
+
+	return nil
+}
+
+// handleAPIError handles errors returned from the CipherSwarm API. Logs error messages and sends error reports based on the error type.
+// Parameters:
+// - message: Description of the error context.
+// - err: The original error object encountered.
+// - severity: The severity level of the error for reporting.
+func handleAPIError(message string, err error, severity operations.Severity) {
+	switch e := err.(type) {
+	case *sdkerrors.ErrorObject:
+		shared.Logger.Error(message, "error", e.Error())
+		SendAgentError(e.Error(), nil, severity)
+	case *sdkerrors.SDKError:
+		shared.Logger.Error(message+", unexpected error",
+			"status_code", e.StatusCode,
+			"message", e.Message)
+		SendAgentError(e.Error(), nil, severity)
+	default:
+		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
+	}
+}
+
+// handleHeartbeatError processes and logs errors occurring during the heartbeat operation.
+// It handles different types of errors and manages logging and reporting based on severity.
+// - For *sdkerrors.ErrorObject: logs a critical error and sends a critical agent error message.
+// - For *sdkerrors.SDKError: logs an unexpected error with status code and message, and sends a critical agent error message.
+// - For all other errors: logs a critical communication error with the CipherSwarm API.
+func handleHeartbeatError(err error) {
+	switch e := err.(type) {
+	case *sdkerrors.ErrorObject:
+		_ = logAndSendError("Error sending heartbeat", e, operations.SeverityCritical, nil)
+	case *sdkerrors.SDKError:
+		shared.Logger.Error("Error sending heartbeat, unexpected error",
+			"status_code", e.StatusCode,
+			"message", e.Message)
+		SendAgentError(e.Error(), nil, operations.SeverityCritical)
+	default:
+		shared.ErrorLogger.Error("Error communicating with the CipherSwarm API", "error", err)
+	}
+}
+
+// handleStatusUpdateError handles specific error types during a status update and logs or processes them accordingly.
+func handleStatusUpdateError(err error, task *components.Task, sess *hashcat.Session) {
+	var eo *sdkerrors.ErrorObject
+	if errors.As(err, &eo) {
+		_ = logAndSendError("Error sending status update", eo, operations.SeverityCritical, task)
+
+		return
+	}
+
+	var se *sdkerrors.SDKError
+	if errors.As(err, &se) {
+		handleSDKError(se, task, sess)
+
+		return
+	}
+
+	shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
+}
+
+// handleSDKError handles errors from the SDK by taking appropriate action based on the error's status code.
+func handleSDKError(se *sdkerrors.SDKError, task *components.Task, sess *hashcat.Session) {
+	switch se.StatusCode {
+	case http.StatusNotFound:
+		// Not an error, just log and kill the task
+		handleTaskNotFound(task, sess)
+	case http.StatusGone:
+		// Not an error, just log and pause the task
+		handleTaskGone(task, sess)
+	default:
+		_ = logAndSendError("Error connecting to the CipherSwarm API, unexpected error", se, operations.SeverityCritical, task)
+	}
+}
+
+// handleTaskNotFound handles the scenario where a task is not found in the system.
+// It logs an error message with the task ID, attempts to kill the session, and cleans up the session.
+// If killing the session fails, it logs and sends an error.
+func handleTaskNotFound(task *components.Task, sess *hashcat.Session) {
+	shared.Logger.Error("Task not found", "task_id", task.GetID())
+	shared.Logger.Info("Killing task", "task_id", task.GetID())
+	shared.Logger.Info("It is possible that multiple errors appear as the task takes some time to kill. This is expected.")
+	if err := sess.Kill(); err != nil {
+		_ = logAndSendError("Error killing task", err, operations.SeverityCritical, task)
+	}
+	sess.Cleanup()
+}
+
+// handleTaskGone handles the termination of a task when it is no longer needed, ensuring the session is appropriately killed.
+func handleTaskGone(task *components.Task, sess *hashcat.Session) {
+	shared.Logger.Info("Pausing task", "task_id", task.GetID())
+	if err := sess.Kill(); err != nil {
+		_ = logAndSendError("Error pausing task", err, operations.SeverityFatal, task)
+	}
+}
+
+// handleGetZapsError handles different types of errors when fetching zaps from the server.
+// - If the error is of type sdkerrors.ErrorObject, it logs the error and sends a critical agent error message.
+// - If the error is of type sdkerrors.SDKError, it logs an unexpected error with its status code and message, then sends a critical agent error message.
+// - For all other errors, it logs a critical communication error with the CipherSwarm API.
+func handleGetZapsError(err error) {
+	switch e := err.(type) {
+	case *sdkerrors.ErrorObject:
+		shared.Logger.Error("Error getting zaps from server", "error", e.Error())
+		SendAgentError(e.Error(), nil, operations.SeverityCritical)
+	case *sdkerrors.SDKError:
+		shared.Logger.Error("Error getting zaps from server, unexpected error",
+			"status_code", e.StatusCode,
+			"message", e.Message)
+		SendAgentError(e.Error(), nil, operations.SeverityCritical)
+	default:
+		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
+	}
+}
+
+// handleResponseStream processes a received response stream for a given task, writing it to a zap file on disk.
+// Constructs the zap file path from the task ID, removes existing zap files if necessary, and writes the new zap file.
+// Logs debug information for non-critical errors when removing existing files and logs critical errors for failures in creating or writing the zap file.
+func handleResponseStream(task *components.Task, responseStream io.Reader) error {
+	zapFilePath := path.Join(shared.State.ZapsPath, fmt.Sprintf("%d.zap", task.GetID()))
+
+	if err := removeExistingZapFile(zapFilePath); err != nil {
+		// It's not critical to remove the existing zap file since we're going to overwrite it anyway
+		_ = logAndSendError("Error removing existing zap file", err, operations.SeverityCritical, task)
+	}
+
+	if err := createAndWriteZapFile(zapFilePath, responseStream, task); err != nil {
+		// This is a critical error since we need the zap file to be written
+		return logAndSendError("Error handling zap file", err, operations.SeverityCritical, task)
+	}
+
+	return nil
+}
+
+// SendAgentError sends an error message to the centralized server, including metadata and severity level.
+// - stdErrLine: The error message string to send.
+// - task: Pointer to the task associated with the error, can be nil.
+// - severity: The severity level of the error (e.g., critical, warning).
+// The function prepares metadata including platform and agent version details, constructs the request body,
+// and sends it to the server using the SDK client. If the sending fails, it handles the error accordingly.
+func SendAgentError(stdErrLine string, task *components.Task, severity operations.Severity) {
+	var taskID *int64
+	if task != nil {
+		taskID = &task.ID
+	}
+
+	metadata := &operations.Metadata{
+		ErrorDate: time.Now(),
+		Other: map[string]any{
+			"platform": agentPlatform,
+			"version":  AgentVersion,
+		},
+	}
+
+	agentError := &operations.SubmitErrorAgentRequestBody{
+		Message:  stdErrLine,
+		Metadata: metadata,
+		Severity: severity,
+		AgentID:  shared.State.AgentID,
+		TaskID:   taskID,
+	}
+
+	if _, err := SdkClient.Agents.SubmitErrorAgent(Context, shared.State.AgentID, agentError); err != nil {
+		handleSendError(err)
+	}
+}
+
+// handleSendError handles errors that occur during communication with the server.
+// It logs the error locally and attempts to send critical errors to the server.
+func handleSendError(err error) {
+	switch e := err.(type) {
+	case *sdkerrors.ErrorObject:
+		shared.Logger.Error("Error sending agent error to server", "error", e.Error())
+		SendAgentError(e.Error(), nil, operations.SeverityCritical)
+	case *sdkerrors.SDKError:
+		shared.Logger.Error("Error sending agent error to server, unexpected error",
+			"status_code", e.StatusCode,
+			"message", e.Message)
+		SendAgentError(e.Error(), nil, operations.SeverityCritical)
+	default:
+		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
+	}
+}
+
+// handleAcceptTaskError handles errors that occur when attempting to accept a task.
+// It distinguishes between different error types and logs messages accordingly.
+// For specific SDK errors, it logs the error and sends an info-severity agent error.
+// For unexpected SDK errors, it logs the error including status code and message, and sends a critical-severity agent error.
+// For all other errors, it logs a critical communication error.
+func handleAcceptTaskError(err error) {
+	switch e := err.(type) {
+	case *sdkerrors.ErrorObject:
+		// Handle specific error responses
+		shared.Logger.Error("Error accepting task", "error", e.Error())
+		SendAgentError(e.Error(), nil, operations.SeverityInfo)
+	case *sdkerrors.SDKError:
+		// Handle unexpected errors
+		shared.Logger.Error("Error accepting task, unexpected error",
+			"status_code", e.StatusCode,
+			"message", e.Message)
+		SendAgentError(e.Error(), nil, operations.SeverityCritical)
+	default:
+		// Handle critical communication errors
+		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
+	}
+}
+
+// handleTaskError handles different types of errors encountered during task operations and logs appropriate messages.
+// It sends error details to a centralized server based on the error's severity level.
+func handleTaskError(err error, message string) {
+	switch e := err.(type) {
+	case *sdkerrors.ErrorObject:
+		shared.Logger.Error(message, "error", e.Error())
+		SendAgentError(e.Error(), nil, operations.SeverityCritical)
+	case *sdkerrors.SetTaskAbandonedResponseBody:
+		shared.Logger.Error("Notified server of task abandonment, but it could not update the task properly", "error", e.State)
+		SendAgentError(e.Error(), nil, operations.SeverityWarning)
+	case *sdkerrors.SDKError:
+		shared.Logger.Error(message, "status_code", e.StatusCode, "message", e.Message)
+		SendAgentError(e.Error(), nil, operations.SeverityCritical)
+	default:
+		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
+	}
+}
+
+// handleSendCrackError processes different types of errors encountered when communicating with the CipherSwarm API.
+// Logs errors based on their type and reports major or critical severity, or logs a critical error for unknown types.
+func handleSendCrackError(err error) {
+	switch e := err.(type) {
+	case *sdkerrors.ErrorObject:
+		shared.Logger.Error("Error notifying server of cracked hash, task not found", "error", e.Error())
+		SendAgentError(e.Error(), nil, operations.SeverityMajor)
+	case *sdkerrors.SDKError:
+		shared.Logger.Error("Error sending cracked hash to server, unexpected error",
+			"status_code", e.StatusCode,
+			"message", e.Message)
+		SendAgentError(e.Error(), nil, operations.SeverityCritical)
+	default:
+		shared.ErrorLogger.Error("Critical error communicating with the CipherSwarm API", "error", err)
+	}
+}

--- a/lib/fileUtils.go
+++ b/lib/fileUtils.go
@@ -1,0 +1,139 @@
+package lib
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/duke-git/lancet/v2/cryptor"
+	"github.com/duke-git/lancet/v2/fileutil"
+	"github.com/duke-git/lancet/v2/strutil"
+	"github.com/duke-git/lancet/v2/validator"
+	"github.com/hashicorp/go-getter"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/components"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/operations"
+	"github.com/unclesp1d3r/cipherswarmagent/lib/hashcat"
+	"github.com/unclesp1d3r/cipherswarmagent/lib/utils"
+	"github.com/unclesp1d3r/cipherswarmagent/shared"
+	"os"
+	"path"
+)
+
+// downloadFile downloads a file from a given URL and saves it to the specified path with optional checksum verification.
+// If the URL is invalid, it returns an error. If the file already exists and the checksum matches, the download is skipped.
+func downloadFile(url string, path string, checksum string) error {
+	if !validator.IsUrl(url) {
+		shared.Logger.Error("Invalid URL", "url", url)
+
+		return errors.New("invalid URL")
+	}
+
+	if fileExistsAndValid(path, checksum) {
+		shared.Logger.Info("Download already exists", "path", path)
+
+		return nil
+	}
+
+	displayDownloadFile(url, path)
+	if err := downloadAndVerifyFile(url, path, checksum); err != nil {
+		return err
+	}
+	displayDownloadFileComplete(url, path)
+
+	return nil
+}
+
+// fileExistsAndValid checks if a file exists at the given path and, if a checksum is provided, verifies its validity.
+// The function returns true if the file exists and matches the given checksum, or if no checksum is provided.
+// If the file does not exist or the checksum verification fails, appropriate error messages are logged.
+func fileExistsAndValid(path string, checksum string) bool {
+	if !fileutil.IsExist(path) {
+		return false
+	}
+
+	if strutil.IsBlank(checksum) {
+		return true
+	}
+
+	fileChecksum, err := cryptor.Md5File(path)
+	if err != nil {
+		shared.Logger.Error("Error calculating file checksum", "path", path, "error", err)
+
+		return false
+	}
+
+	if fileChecksum == checksum {
+		return true
+	}
+
+	shared.Logger.Warn("Checksums do not match", "path", path, "url_checksum", checksum, "file_checksum", fileChecksum)
+	SendAgentError("Resource "+path+" exists, but checksums do not match", nil, operations.SeverityInfo)
+	if err := os.Remove(path); err != nil {
+		SendAgentError(err.Error(), nil, operations.SeverityMajor)
+		shared.Logger.Error("Error removing file with mismatched checksum", "path", path, "error", err)
+	}
+
+	return false
+}
+
+// downloadAndVerifyFile downloads a file from the given URL and saves it to the specified path, verifying the checksum if provided.
+// If a checksum is given, it is appended to the URL before download. The function then configures a client for secure file transfer.
+// The file is downloaded using the configured client. After downloading, the file's checksum is verified, if provided, to ensure integrity.
+// If the checksum does not match, an error is returned, indicating the downloaded file is corrupt.
+func downloadAndVerifyFile(url string, path string, checksum string) error {
+	if strutil.IsNotBlank(checksum) {
+		var err error
+		url, err = appendChecksumToURL(url, checksum)
+		if err != nil {
+			return err
+		}
+	}
+
+	client := &getter.Client{
+		Ctx:      context.Background(),
+		Dst:      path,
+		Src:      url,
+		Pwd:      shared.State.CrackersPath,
+		Insecure: true,
+		Mode:     getter.ClientModeFile,
+	}
+
+	_ = client.Configure(
+		getter.WithProgress(utils.DefaultProgressBar),
+		getter.WithUmask(os.FileMode(0o022)),
+	)
+
+	if err := client.Get(); err != nil {
+		shared.Logger.Debug("Error downloading file", "error", err)
+
+		return err
+	}
+
+	if strutil.IsNotBlank(checksum) && !fileExistsAndValid(path, checksum) {
+		return errors.New("downloaded file checksum does not match")
+	}
+
+	return nil
+}
+
+// cleanupTempDir removes the specified temporary directory and logs any errors encountered. Returns the error if removal fails.
+func cleanupTempDir(tempDir string) error {
+	if err := os.RemoveAll(tempDir); err != nil {
+		return logAndSendError("Error removing temporary directory", err, operations.SeverityCritical, nil)
+	}
+
+	return nil
+}
+
+// writeCrackedHashToFile writes a cracked hash and its plaintext to a specified file.
+// It constructs the output string using the hash and plaintext, then writes it to a task-specific file in the ZapsPath.
+// Returns an error if the file writing operation fails.
+func writeCrackedHashToFile(hash hashcat.Result, task *components.Task) error {
+	hashOut := fmt.Sprintf("%s:%s\n", hash.Hash, hash.Plaintext)
+	hashFile := path.Join(shared.State.ZapsPath, fmt.Sprintf("%d_clientout.zap", task.GetID()))
+	err := fileutil.WriteStringToFile(hashFile, hashOut, true)
+	if err != nil {
+		return logAndSendError("Error writing cracked hash to file", err, operations.SeverityCritical, task)
+	}
+
+	return nil
+}

--- a/lib/taskManager.go
+++ b/lib/taskManager.go
@@ -1,0 +1,167 @@
+package lib
+
+import (
+	"errors"
+	"github.com/duke-git/lancet/v2/convertor"
+	"github.com/duke-git/lancet/v2/pointer"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/components"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/operations"
+	"github.com/unclesp1d3r/cipherswarmagent/lib/arch"
+	"github.com/unclesp1d3r/cipherswarmagent/lib/hashcat"
+	"github.com/unclesp1d3r/cipherswarmagent/shared"
+	"net/http"
+	"path"
+)
+
+// GetNewTask retrieves a new task from the server.
+// It sends a request using SdkClient, handles any errors, and returns the task if available.
+// If the server responds with no content, it means no new task is available, and the function returns nil without error.
+// For any other unexpected response status, an error is returned.
+func GetNewTask() (*components.Task, error) {
+	response, err := SdkClient.Tasks.GetNewTask(Context)
+	if err != nil {
+		handleAPIError("Error getting new task", err, operations.SeverityCritical)
+
+		return nil, err
+	}
+
+	switch response.StatusCode {
+	case http.StatusNoContent:
+		// No new task available
+		return nil, nil
+	case http.StatusOK:
+		// New task available
+		return response.Task, nil
+	default:
+		return nil, errors.New("bad response: " + response.RawResponse.Status)
+	}
+}
+
+// GetAttackParameters retrieves the attack parameters for a given attackID via the SdkClient.
+// Returns an Attack object if the API call is successful and the response status is OK.
+func GetAttackParameters(attackID int64) (*components.Attack, error) {
+	response, err := SdkClient.Attacks.GetAttack(Context, attackID)
+	if err != nil {
+		handleAPIError("Error getting attack parameters", err, operations.SeverityCritical)
+
+		return nil, err
+	}
+
+	if response.StatusCode == http.StatusOK {
+		return response.Attack, nil
+	}
+
+	return nil, errors.New("bad response: " + response.RawResponse.Status)
+}
+
+// createJobParams creates hashcat parameters from the given Task and Attack objects.
+// The function initializes a hashcat.Params struct by extracting and converting fields
+// from the Task and Attack objects. It includes path settings for various resources
+// like hash files, word lists, rule lists, and restore files.
+func createJobParams(task *components.Task, attack *components.Attack) hashcat.Params {
+	return hashcat.Params{
+		AttackMode:       pointer.UnwrapOr(attack.AttackModeHashcat),
+		HashType:         pointer.UnwrapOr(attack.HashMode),
+		HashFile:         path.Join(shared.State.HashlistPath, convertor.ToString(attack.GetHashListID())+".txt"),
+		Mask:             pointer.UnwrapOr(attack.GetMask(), ""),
+		MaskIncrement:    pointer.UnwrapOr(attack.GetIncrementMode(), false),
+		MaskIncrementMin: attack.GetIncrementMinimum(),
+		MaskIncrementMax: attack.GetIncrementMaximum(),
+		MaskCustomCharsets: []string{
+			pointer.UnwrapOr(attack.GetCustomCharset1(), ""),
+			pointer.UnwrapOr(attack.GetCustomCharset2(), ""),
+			pointer.UnwrapOr(attack.GetCustomCharset3(), ""),
+			pointer.UnwrapOr(attack.GetCustomCharset4(), ""),
+		},
+		WordListFilename: resourceNameOrBlank(attack.WordList),
+		RuleListFilename: resourceNameOrBlank(attack.RuleList),
+		MaskListFilename: resourceNameOrBlank(attack.MaskList),
+		AdditionalArgs:   arch.GetAdditionalHashcatArgs(),
+		OptimizedKernels: *attack.Optimized,
+		SlowCandidates:   *attack.SlowCandidateGenerators,
+		Skip:             pointer.UnwrapOr(task.GetSkip(), 0),
+		Limit:            pointer.UnwrapOr(task.GetLimit(), 0),
+		BackendDevices:   Configuration.Config.BackendDevices,
+		OpenCLDevices:    Configuration.Config.OpenCLDevices,
+		RestoreFilePath:  path.Join(shared.State.RestoreFilePath, convertor.ToString(attack.GetID())+".restore"),
+	}
+}
+
+// AcceptTask attempts to accept the given task identified by its ID.
+// It logs an error and returns if the task is nil.
+// If the task is successfully accepted, it logs a debug message indicating success.
+// In case of an error during task acceptance, it handles the error and returns it.
+func AcceptTask(task *components.Task) error {
+	if task == nil {
+		shared.Logger.Error("Task is nil")
+
+		return errors.New("task is nil")
+	}
+
+	_, err := SdkClient.Tasks.SetTaskAccepted(Context, task.GetID())
+	if err != nil {
+		handleAcceptTaskError(err)
+
+		return err
+	}
+
+	shared.Logger.Debug("Task accepted")
+
+	return nil
+}
+
+// markTaskExhausted marks the given task as exhausted by notifying the server.
+// Logs an error if the task is nil or if notifying the server fails.
+func markTaskExhausted(task *components.Task) {
+	if task == nil {
+		shared.Logger.Error("Task is nil")
+
+		return
+	}
+
+	_, err := SdkClient.Tasks.SetTaskExhausted(Context, task.GetID())
+	if err != nil {
+		handleTaskError(err, "Error notifying server of task exhaustion")
+	}
+}
+
+// AbandonTask sets the given task to an abandoned state using the SdkClient and logs any errors that occur.
+// If the task is nil, it logs an error and returns immediately.
+func AbandonTask(task *components.Task) {
+	if task == nil {
+		shared.Logger.Error("Task is nil")
+
+		return
+	}
+
+	_, err := SdkClient.Tasks.SetTaskAbandoned(Context, task.GetID())
+	if err != nil {
+		handleTaskError(err, "Error notifying server of task abandonment")
+	}
+}
+
+// RunTask performs a hashcat attack based on the provided task and attack objects.
+// It initializes the task, creates job parameters, starts the hashcat session, and handles task completion or errors.
+// Parameters:
+//   - task: Pointer to the Task object to be run.
+//   - attack: Pointer to the Attack object describing the specifics of the attack.
+//
+// Returns an error if the task could not be run or if the attack session could not be started.
+func RunTask(task *components.Task, attack *components.Attack) error {
+	displayRunTaskStarting(task)
+
+	if attack == nil {
+		return logAndSendError("Attack is nil", errors.New("attack is nil"), operations.SeverityCritical, task)
+	}
+
+	jobParams := createJobParams(task, attack)
+	sess, err := hashcat.NewHashcatSession(convertor.ToString(attack.GetID()), jobParams)
+	if err != nil {
+		return logAndSendError("Failed to create attack session", err, operations.SeverityCritical, task)
+	}
+
+	runAttackTask(sess, task)
+	displayRunTaskCompleted()
+
+	return nil
+}

--- a/lib/testManager.go
+++ b/lib/testManager.go
@@ -1,0 +1,115 @@
+package lib
+
+import (
+	"github.com/duke-git/lancet/v2/strutil"
+	"github.com/duke-git/lancet/v2/validator"
+	"github.com/pkg/errors"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/operations"
+	"github.com/unclesp1d3r/cipherswarmagent/lib/arch"
+	"github.com/unclesp1d3r/cipherswarmagent/lib/hashcat"
+	"github.com/unclesp1d3r/cipherswarmagent/shared"
+)
+
+// getDevices initializes a test Hashcat session and runs a test task, returning the names of available OpenCL devices.
+// An error is logged and returned if the session creation or test task execution fails.
+func getDevices() ([]string, error) {
+	jobParams := hashcat.Params{
+		AttackMode:     hashcat.AttackModeMask,
+		AdditionalArgs: arch.GetAdditionalHashcatArgs(),
+		HashFile:       "60b725f10c9c85c70d97880dfe8191b3", // "a"
+		Mask:           "?l",
+		OpenCLDevices:  "1,2,3",
+	}
+
+	sess, err := hashcat.NewHashcatSession("test", jobParams)
+	if err != nil {
+		return nil, logAndSendError("Failed to create test session", err, operations.SeverityMajor, nil)
+	}
+
+	testStatus, err := runTestTask(sess)
+	if err != nil {
+		return nil, logAndSendError("Error running test task", err, operations.SeverityFatal, nil)
+	}
+
+	return extractDeviceNames(testStatus.Devices), nil
+}
+
+// extractDeviceNames extracts the device names from a slice of hashcat.StatusDevice and returns them as a slice of strings.
+func extractDeviceNames(deviceStatuses []hashcat.StatusDevice) []string {
+	devices := make([]string, len(deviceStatuses))
+	for i, device := range deviceStatuses {
+		devices[i] = device.DeviceName
+	}
+
+	return devices
+}
+
+// runTestTask runs a hashcat test session, handles various output channels, and returns the session status or an error.
+func runTestTask(sess *hashcat.Session) (*hashcat.Status, error) {
+	err := sess.Start()
+	if err != nil {
+		shared.Logger.Error("Failed to start hashcat startup test session", "error", err)
+		SendAgentError(err.Error(), nil, operations.SeverityFatal)
+
+		return nil, err
+	}
+
+	var testResults *hashcat.Status
+	var errorResult error
+	waitChan := make(chan struct{})
+
+	go func() {
+		defer close(waitChan)
+		for {
+			select {
+			case stdoutLine := <-sess.StdoutLines:
+				handleTestStdOutLine(stdoutLine)
+			case stdErrLine := <-sess.StderrMessages:
+				handleTestStdErrLine(stdErrLine, &errorResult)
+			case statusUpdate := <-sess.StatusUpdates:
+				testResults = &statusUpdate
+			case crackedHash := <-sess.CrackedHashes:
+				handleTestCrackedHash(crackedHash, &errorResult)
+			case err := <-sess.DoneChan:
+				handleTestDoneChan(err, &errorResult)
+				sess.Cleanup()
+
+				return
+			}
+		}
+	}()
+
+	<-waitChan
+
+	return testResults, errorResult
+}
+
+// handleTestStdOutLine processes a line of standard output from a test, logging an error if the line isn't valid JSON.
+func handleTestStdOutLine(stdoutLine string) {
+	if !validator.IsJSON(stdoutLine) {
+		shared.Logger.Error("Failed to parse status update", "output", stdoutLine)
+	}
+}
+
+// handleTestStdErrLine sends the specified stderr line to the central server and sets the provided error result.
+func handleTestStdErrLine(stdErrLine string, errorResult *error) {
+	if strutil.IsNotBlank(stdErrLine) {
+		SendAgentError(stdErrLine, nil, operations.SeverityMinor)
+		*errorResult = errors.New(stdErrLine)
+	}
+}
+
+// handleTestCrackedHash processes a cracked hash result from hashcat and sets an error if the plaintext is blank.
+func handleTestCrackedHash(crackedHash hashcat.Result, errorResult *error) {
+	if strutil.IsBlank(crackedHash.Plaintext) {
+		*errorResult = errors.New("received empty cracked hash")
+	}
+}
+
+// handleTestDoneChan handles errors from the test session's done channel, sends them to central server if not exit status 1.
+func handleTestDoneChan(err error, errorResult *error) {
+	if err != nil && err.Error() != "exit status 1" {
+		SendAgentError(err.Error(), nil, operations.SeverityCritical)
+		*errorResult = err
+	}
+}


### PR DESCRIPTION
This commit moves the previous functions in agentClient and clientUtils into purpose-specific files. The overall codebase is now more maintainable and easier to navigate.