### PR TITLE
Fix hashlist download error handling

### DIFF
--- a/lib/clientUtils.go
+++ b/lib/clientUtils.go
@@ -197,7 +197,7 @@ func downloadHashList(attack *components.Attack) error {
 
 	response, err := SdkClient.Attacks.GetHashList(Context, attack.ID)
 	if err != nil {
-		return logAndSendError("Error downloading hashlist from the CipherSwarm API", nil, operations.SeverityCritical, nil)
+		return logAndSendError("Error downloading hashlist from the CipherSwarm API", err, operations.SeverityCritical, nil)
 	}
 
 	if response.StatusCode != http.StatusOK {

--- a/lib/clientUtils_test.go
+++ b/lib/clientUtils_test.go
@@ -1,8 +1,41 @@
 package lib
 
 import (
+	"context"
+	"errors"
+	"net/http"
 	"testing"
+
+	sdk "github.com/unclesp1d3r/cipherswarm-agent-sdk-go"
+	"github.com/unclesp1d3r/cipherswarm-agent-sdk-go/models/components"
+
+	"github.com/unclesp1d3r/cipherswarmagent/shared"
 )
+
+// errorHTTPClient is a stub HTTP client that always returns an error.
+type errorHTTPClient struct{}
+
+func (errorHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return nil, errors.New("http error")
+}
+
+// TestDownloadHashListError ensures downloadHashList does not panic when the
+// API client returns an error.
+func TestDownloadHashListError(t *testing.T) {
+	// Prepare a temporary directory for hashlists.
+	dir := t.TempDir()
+	shared.State.HashlistPath = dir
+
+	// Initialize the SDK client with the error HTTP client.
+	SdkClient = sdk.New(sdk.WithClient(errorHTTPClient{}))
+	Context = context.Background()
+
+	attack := &components.Attack{ID: 1, HashListID: 1}
+
+	if err := downloadHashList(attack); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
 
 func TestDummy(t *testing.T) {
 	t.Log("Basic test structure for clientUtils.go")


### PR DESCRIPTION
## Summary
- return the SDK error when `GetHashList` fails
- test `downloadHashList` gracefully handles API errors

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ced0127608333b5b444613a0a0c02