### PR TITLE
feat: submit benchmarks incrementally with per-item tracking

### DIFF
--- a/lib/dataTypes.go
+++ b/lib/dataTypes.go
@@ -42,4 +42,5 @@ type benchmarkResult struct {
 	RuntimeMs  string `json:"runtime,omitempty"`    // RuntimeMs is the runtime of the benchmark in milliseconds.
 	HashTimeMs string `json:"hash_time,omitempty"`  // HashTimeMs is the time taken to hash in milliseconds.
 	SpeedHs    string `json:"hash_speed,omitempty"` // SpeedHs is the hash speed in hashes per second.
+	Submitted  bool   `json:"submitted,omitempty"`  // Submitted indicates whether this result has been accepted by the server.
 }


### PR DESCRIPTION
## Summary

- Submit benchmark results in batches of 10 during benchmarking, giving the server real-time visibility into progress
- Track per-item submission state via a `Submitted` field on `benchmarkResult`, eliminating duplicate submissions when earlier batches fail but later ones succeed
- Persist cache with submission flags after each successful batch for crash recovery
- Extract `processBenchmarkOutput` from `runBenchmarkTask` for testability, add `drainStdout` to handle buffered channel data

## Test plan

- [x] `go test -race ./lib/...` passes with no races
- [x] `just ci-check` passes (lint, vet, format, tests)
- [x] 6 `processBenchmarkOutput` test scenarios (all succeed, single batch, batch fails, all fail, empty, session error)
- [x] Helper function tests (`unsubmittedResults`, `allSubmitted`, `markSubmitted`)
- [x] Cache tests for partially submitted, fully submitted, and backward-compatible old format
- [x] Updated `cacheAndSubmitBenchmarks` and `TrySubmitCachedBenchmarks` tests for `Submitted` field
- [ ] Integration test with live hashcat and CipherSwarm server

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented incremental batch-based submission of benchmark results for improved reliability.
  * Added automatic retry capability for failed benchmark submissions with intelligent caching.
  * Enhanced tracking of benchmark submission status to identify successfully submitted versus pending results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->